### PR TITLE
feat: status barの下にbaseの色を追加

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,0 +1,14 @@
+html{
+    height: 100%;
+    width:100%;
+}
+body{
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: #FF8C00
+}
+#root {
+    background: #ffffff;
+    height: 100%;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,10 @@
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icons/app-icon-192x192.png">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+    <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icons/app-icon-192x192.png"/>
 
+    <link rel="stylesheet" href='./index.css'/>
     <title>FUNney</title>
   </head>
   <body style="margin: 0">

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,13 +7,16 @@ const useStyles = makeStyles({
   title: {
     color: 'white',
   },
+  app_bar: {
+    position: 'fixed',
+  },
 });
 
 function Header() {
   const classes = useStyles();
   const { path } = useSelector(state => state.pathReducer);
   return (
-    <AppBar position="static">
+    <AppBar position="static" className={classes.app_bar}>
       <Toolbar>
         <Typography variant="h6" className={classes.title}>
           {path}


### PR DESCRIPTION
## 関連URL

↓issueのURL  
close #3 

他  

## 概要

- headerのポジションをfixedにしました。
fixedにすることでscroll時にheaderが流れない。
- status bar の色をheaderと同じにしました。
色が浮いていて見た目が悪かったので改善です

## 技術的変更点概要
- headerはcss in js のスタイルに則り、fixedの設定を足しました。
- html、bodyの高さが子要素の高さに依存してたのでindex.cssに全体で共有する設定を少しだけ書きました。

## 使い方
いつもと変わりません

## UIに対する変更

![IMG_1127](https://user-images.githubusercontent.com/28254068/60264823-1d880480-991f-11e9-868b-b88aab32ff16.PNG)

