### PR TITLE
style: bottom navigationの修正

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,13 +2,24 @@ import React from 'react';
 import { Link } from 'react-router-dom'
 import BottomNavigation from '@material-ui/core/BottomNavigation';
 import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
+import { makeStyles } from '@material-ui/core/styles';
 
 import HomeIcon from '@material-ui/icons/Home';
 import SendIcon from '@material-ui/icons/Send';
 import SettingsIcon from '@material-ui/icons/Settings';
 
+
+const useStyles = makeStyles({
+  bottom_nav: {
+    position: 'fixed',
+    bottom: '0',
+    width: '100%'
+  },
+});
+
 // TODO: 位置の調整
 function Footer() {
+  const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
   return (
@@ -18,6 +29,7 @@ function Footer() {
         setValue(newValue);
       }}
       showLabels
+      className={classes.bottom_nav}
     >
       <BottomNavigationAction component={Link}  to="/" label="Home" icon={<HomeIcon />} />
       <BottomNavigationAction component={Link} to="/send" label="Send" icon={<SendIcon />} />


### PR DESCRIPTION
## 関連URL

↓issueのURL  
close #4 

他  

## 概要
- bottom navigationを常に下に配置されるように変更

## 技術的変更点概要

- bottom  navigationに styleをあてることで常にしたいに配置されるようにした

## 使い方

- スクロールしてもスクロールされないことをだれか確認してほしい


## UIに対する変更

- 変更前のスクリーンショット
![IMG_1141](https://user-images.githubusercontent.com/28254068/60384021-0af30400-9ab4-11e9-8db1-3281c2e6414d.PNG)

- 変更後のスクリーンショット
![localhost_3000_settings(iPhone 6_7_8) (3)](https://user-images.githubusercontent.com/28254068/60384014-f9116100-9ab3-11e9-8168-3706f1284807.png)

