### PR TITLE
Send画面の見た目の作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7011,7 +7011,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7029,11 +7030,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7046,15 +7049,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7157,7 +7163,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7167,6 +7174,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7179,17 +7187,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7206,6 +7217,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7278,7 +7290,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7288,6 +7301,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7363,7 +7377,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7393,6 +7408,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7410,6 +7426,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7448,11 +7465,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/src/actions/Send.js
+++ b/src/actions/Send.js
@@ -1,0 +1,18 @@
+export const sendRequest = (data) => {
+  return {
+    type: 'SEND_REQUEST',
+    data,
+  }
+};
+
+export const sendSuccess = () => {
+  return {
+    type: 'SEND_SUCCESS',
+  }
+};
+
+export const sendFailed = () => {
+  return {
+    type: 'SEND_FAILED',
+  }
+};

--- a/src/apis/Send.js
+++ b/src/apis/Send.js
@@ -1,0 +1,14 @@
+import * as request from 'superagent';
+
+export function sendApi(data) {
+  return request
+    .post(`https://funfintech.tk/api/v1/transaction`)
+    .send({balance: parseInt(data.balance), id: data.id, send_id: data.send_id})
+    .then(response => {
+      const body = response.body;
+      return { body };
+    })
+    .catch(error => {
+      return { error };
+    });
+}

--- a/src/components/Send.js
+++ b/src/components/Send.js
@@ -1,16 +1,96 @@
 import React, {useEffect} from "react";
-import { useDispatch } from "react-redux";
+import {useDispatch, useSelector} from "react-redux";
 import { setPath } from "../actions/Path";
+import { sendRequest } from "../actions/Send";
 
-// TODO:送金フォームと確認ダイアログ
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import signInReducer from "../reducers/SignIn";
+
+
+const useStyles = makeStyles(theme => ({
+  SendPage: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    gridRow: '2',
+  },
+  SendBox: {
+    width: "80vw",
+    maxWidth: 800,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center"
+  },
+  TextFieldForMoney: {
+    width: "100%",
+  },
+  TextFieldForNumber: {
+    width: "100%",
+    marginTop: "5vh",
+    marginBottom: "8vh"
+  },
+  button: {
+    width: "40%",
+    backgroundColor: '#FF8C00',
+    color: '#ffffff',
+  }
+}));
+
 function Send() {
+  const classes = useStyles();
   const dispatch = useDispatch();
+  const { id } = useSelector(state => state.signInReducer);
   useEffect(() => {
     dispatch(setPath('Send'))
   });
 
+  function send(){
+    dispatch(sendRequest({balance: value.money, id, send_id: value.number}))
+  }
+
+  const [value, setValue] = React.useState({
+    money: "",
+    number: "",
+  });
+
   return (
-    <div>送金用のページ</div>
+    <div className={classes.SendPage}>
+      <div className={classes.SendBox}>
+        <TextField
+          id="standard-dense"
+          label="送金金額"
+          className={classes.TextFieldForMoney}
+          margin="dense"
+          onChange={e => {
+            setValue({
+              ...value,
+              money: e.target.value,
+            })
+          }}
+        />
+        <TextField
+          id="standard-dense"
+          label="送り先 学籍番号"
+          className={classes.TextFieldForNumber}
+          margin="dense"
+          onChange={e => {
+            setValue({
+              ...value,
+              number: e.target.value,
+            })
+          }}
+        />
+        <Button
+          variant="contained"
+          className={classes.button}
+          onClick={send}>
+          Send
+        </Button>
+      </div>
+    </div>
   )
 }
 

--- a/src/sagas/Send.js
+++ b/src/sagas/Send.js
@@ -1,0 +1,20 @@
+import { call, put, takeEvery } from 'redux-saga/effects';
+import { sendApi } from '../apis/Send';
+import history from '../Helpers/history'
+import {sendFailed, sendSuccess} from "../actions/Send";
+
+function* send(action) {
+  const { error } = yield call(sendApi, action.data);
+  if (error) {
+    yield put(sendFailed());
+  } else {
+    yield put(sendSuccess());
+    yield call(history.push, '/');
+  }
+}
+
+const saga = [
+  takeEvery('SEND_REQUEST', send)
+];
+
+export default saga;

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,9 +1,11 @@
 import { all } from 'redux-saga/effects';
 import SignInSaga from './SignIn';
+import SendSaga from './Send';
 
 export default function* rootSaga() {
   yield all([
-    ...SignInSaga
+    ...SignInSaga,
+    ...SendSaga,
   ]);
 }
 


### PR DESCRIPTION
---

title: "Send画面の見た目の作成"
labels: enhancement
assignees: ''
reviewer: tekoneko1997, vivid344
---

## 関連URL

↓issueのURL  
#oo

他  

## 概要

-  send画面を見えるようにするため。

## 技術的変更点概要

- sendにテキストフィールドとボタンを追加
- ロジックは実装していないですが、一応valueは管理しているので、consoleで確認できます。(後に消す)

## 使い方
- npm install
- npm start

## UIに対する変更
<img width="366" alt="Screen Shot 0031-06-30 at 9 51 57 PM" src="https://user-images.githubusercontent.com/38876275/60396840-532c2800-9b81-11e9-9bc1-49b214313e5e.png">