### PR TITLE
feat: send画面のダイアログの作成

### DIFF
--- a/src/components/Send.js
+++ b/src/components/Send.js
@@ -7,6 +7,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 
+import {Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@material-ui/core';
+
 const useStyles = makeStyles(theme => ({
   SendPage: {
     display: "flex",
@@ -37,6 +39,44 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
+const AlertDialog = (props) => {
+  if(props.flag){
+    return (
+      <div>
+        <Dialog
+          open={true}
+          onClose={()=>{props.closeDialog()}}
+          aria-labelledby="alert-dialog-title"
+          aria-describedby="alert-dialog-description"
+        >
+          <DialogTitle id="alert-dialog-title">{"確認"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              {`${props.number}さんに${props.money}FUNneyを送信しますか`}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={()=>{props.closeDialog()}} color="primary">
+              CANCEL
+            </Button>
+            <Button
+              onClick={() => {
+                props.send()
+                props.closeDialog()
+              }}
+            color="primary" autoFocus>
+              OK
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+  else{
+    return "";
+  }
+}
+
 function Send() {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -52,6 +92,7 @@ function Send() {
   const [value, setValue] = React.useState({
     money: "",
     number: "",
+    dialog_flag: false,
   });
 
   return (
@@ -84,9 +125,25 @@ function Send() {
         <Button
           variant="contained"
           className={classes.button}
-          onClick={send}>
+          onClick={()=>{
+            setValue({
+              ...value,
+              dialog_flag: true,
+            })
+          }}>
           Send
         </Button>
+        <AlertDialog
+          flag={value.dialog_flag}
+          send={send}
+          number={value.number}
+          money={value.money}
+          closeDialog={()=>
+            setValue({
+              ...value,
+              dialog_flag: false,
+            })
+           }/>
       </div>
     </div>
   )


### PR DESCRIPTION
---

title: "[Feature] send画面のダイアログの作成"
labels: enhancement
assignees: ''
reviewer: tekoneko1997, vivid344
---

## 関連URL

↓issueのURL  
close #26 

## 概要

- なぜこの変更をするのか
　ユーザーの誤入力を防ぐため。
- これによってどう解決されるのか
　送信が確定する前に、確認できる。

## 技術的変更点概要

- sendにダイアログを返す関数を実装した。



## 使い方

- 送信を押すとダイアログが出ます。


## UIに対する変更

- 変更後のスクリーンショット
<img width="363" alt="Screen Shot 0031-07-01 at 4 43 52 PM" src="https://user-images.githubusercontent.com/38876275/60419080-72799280-9c1f-11e9-97ea-b3c55bf746d1.png">

