### PR TITLE
style: ヘッダー及びフッターを美しくした

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,16 +1,15 @@
 html{
-    height: 100%;
-    width:100%;
+    height: 100vh;
+    width: 100%;
 }
 body{
     margin: 0;
     padding: 0;
     height: 100%;
-    background: #FF8C00
 }
 #root {
     background: #ffffff;
     height: 100%;
     display: grid;
-    grid-template-rows: 56px 1fr auto;
+    grid-template-rows: calc(env(safe-area-inset-top) + 56px) auto calc(env(safe-area-inset-bottom) + 56px);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -8,13 +8,13 @@ import HomeIcon from '@material-ui/icons/Home';
 import SendIcon from '@material-ui/icons/Send';
 import SettingsIcon from '@material-ui/icons/Settings';
 
-
 const useStyles = makeStyles({
   bottom_nav: {
     position: 'fixed',
     bottom: '0',
     width: '100%',
     gridRow: '3',
+    paddingBottom: 'env(safe-area-inset-bottom)',
   },
 });
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,6 +10,7 @@ const useStyles = makeStyles({
   app_bar: {
     position: 'fixed',
     gridRow: '1',
+    paddingTop: 'env(safe-area-inset-top)',
   },
 });
 


### PR DESCRIPTION
## 概要
今までHeaderの部分を美しく見せるために背景色を指定していたが，あまり美しくなかったので，消してそれに対応しました．

その影響でsignin，signup画面にてステータスバーが見えないと言う問題が発生中です．（バックグラウンドが白のため）
metaタグの切り替えとか出来ないか現在調査中．

## 技術的変更点概要
-  `viewport-fit=cover` をmetaタグに追記し，フルで画面を埋め尽くすようにした．
- それに加え高さの調整が100%だとうまく行かないため，vhに変更

## 使い方
使い方の変更点はありません

## UIに対する変更
- スクロールしたときによしなになっているか
- iphoneXでしか確認していないため，他の端末は要確認
