### PR TITLE
fix: 新規登録からHomeに飛べるバグの修正

### DIFF
--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -80,7 +80,7 @@ function SignUp() {
         </Button>
       </div>
       <div className={classes.signInContainer}>
-        <Link to='/login' className={classes.signIn}>既に登録されている方はこちら</Link>
+        <Link to='/signin' className={classes.signIn}>既に登録されている方はこちら</Link>
       </div>
       <Snackbar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center'}}

--- a/src/sagas/User.js
+++ b/src/sagas/User.js
@@ -43,7 +43,7 @@ function* signUp(action) {
 }
 
 function* signOut() {
-  yield call(history.push, '/login');
+  yield call(history.push, '/signin');
 }
 
 const saga = [


### PR DESCRIPTION
## 概要
新規登録から既に会員登録している方はこちらボタンを押すとHomeに飛んでいた問題の修正

## 技術的変更点概要
LinkのPathを `/login` から `/signin` に変更
